### PR TITLE
curved braces necessary for not_if

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,5 +24,5 @@ include_recipe "xfs"
 # If we have contents at the default location, we try to make the filesystems with the LWRP.
 filesystem_create_all_from_key "filesystems" do
   action :create
-  not_if ( node[:filesystems] == nil || node[:filesystems].empty? )
+  not_if { node[:filesystems] == nil || node[:filesystems].empty? }
 end


### PR DESCRIPTION
without curved braces the function not_if is not valid and chef-solo run fails.
