### PR TITLE
Use mkfs force option when necessary

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -107,8 +107,10 @@ action :create do
 
     log "filesystem #{label} creating #{fstype} on #{device}"
 
+    force_option = force ? '-f' : ''
+
     # We form our mkfs command
-    mkfs_cmd = "mkfs -t #{fstype} #{mkfs_options} -L #{label} #{device}"
+    mkfs_cmd = "mkfs -t #{fstype} #{force_option} #{mkfs_options} -L #{label} #{device}"
   
     if force
  


### PR DESCRIPTION
I was having trouble using force when there was an existing filesystem on the drive (ext2 instead of xfs).  Adding the -f option to mkfs seemed to fix it.
