### PR TITLE
Update lvm cookbook dependency

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -13,7 +13,7 @@ end
 depends 'xfs'
 depends 'lvm', '~> 1.1.0'
 
-attribute'node[:filesystems]',
+attribute 'filesystems',
   :description => "Filesystems to be created and/or mounted",
   :type => "hash",
   :required => "recommended"


### PR DESCRIPTION
This pull request brings in two changes:
- Updates the lvm cookbook dependency to `1.1.x`.
- Update the format of attribute in metadata.rb to avoid warnings.
