### PR TITLE
fix localjumperror for network devices

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -88,20 +88,20 @@ action :create do
   ruby_block 'wait for device' do
     block do
       # TODO: does this effect bind mounts ?
-      net_fs_types = %w(nfs cifs smp nbd)
+      net_fs_types = %w(nfs nfs4 cifs smp nbd)
       if net_fs_types.include? fstype
         Chef::Log.info "#{fstype} is a netfs will not wait for block device"
-        return
-      end
 
-      count = 0
-      until ::File.exist?(device)
-        count += 1
-        sleep 0.3
-        Chef::Log.debug "waiting for #{device} to exist, try # #{count}"
-        if count >= 1000
-          # TODO: make this a paramater
-          raise Timeout::Error, 'Timeout waiting for device'
+      else
+        count = 0
+        until ::File.exist?(device)
+          count += 1
+          sleep 0.3
+          Chef::Log.debug "waiting for #{device} to exist, try # #{count}"
+          if count >= 1000
+            # TODO: make this a paramater
+            raise Timeout::Error, 'Timeout waiting for device'
+          end
         end
       end
     end


### PR DESCRIPTION
### Description

Adds `nfs4` as type to exclude from device-wait, fix that block.

### Issues Resolved

https://github.com/sous-chefs/filesystem/issues/34

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/filesystem/35)
<!-- Reviewable:end -->
