### PR TITLE
Remove xfsprogs-devel package from RHEL, Fedora platforms

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,7 +17,11 @@ platforms:
   - name: centos-7
     driver:
       box: bento/centos-7.3
-
+  
+  - name: rhel-7
+    driver:
+      box: iamseth/rhel-7.3
+ 
   - name: debian-8
     driver:
       box: bento/debian-8.6

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'help@sous-chefs.org'
 description      'Installs/Configures various filesystems'
 license          'Apache-2.0'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.12.1'
+version          '0.12.2'
 source_url       'https://github.com/sous-chefs/filesystem'
 issues_url       'https://github.com/sous-chefs/filesystem/issues'
 chef_version     '>= 12.0' if respond_to?(:chef_version)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,7 +20,7 @@ case node['platform_family']
 when 'debian'
   package %w(xfsprogs xfsdump xfslibs-dev)
 when 'rhel', 'fedora'
-  package %w(xfsprogs xfsprogs-devel)
+  package %w(xfsprogs)
 end
 
 # We want to support LVM

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -2,6 +2,7 @@
 # Cookbook:: test
 # Recipe:: default
 #
+include_recipe 'filesystem::default'
 
 filesystem 'loop-1' do
   fstype 'ext3'
@@ -9,5 +10,14 @@ filesystem 'loop-1' do
   size '10000'
   device '/dev/loop0'
   mount '/mnt/loop-1'
+  action [:create, :enable, :mount]
+end
+
+filesystem 'loop-xfs' do
+  fstype 'xfs'
+  file '/opt/loop-xfs.img'
+  size '10000'
+  device '/dev/loop1'
+  mount '/mnt/loop-xfs'
   action [:create, :enable, :mount]
 end

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -14,3 +14,20 @@ describe mount('/mnt/loop-1') do
   its('device') { should eq '/dev/loop0' }
   its('type') { should eq 'ext3' }
 end
+
+describe file('/opt/loop-xfs.img') do
+  it { should be_file }
+  it { should exist }
+  its('size') { should > 1 }
+end
+
+describe directory('/mnt/loop-xfs') do
+  it { should exist }
+  it { should be_directory }
+end
+
+describe mount('/mnt/loop-xfs') do
+  it { should be_mounted }
+  its('device') { should eq '/dev/loop1' }
+  its('type') { should eq 'xfs' }
+end


### PR DESCRIPTION
### Description
In this change, we avoid installing the `xfsprogs-devel` package on rhel and fedora platforms. This is because the `xfsprogs-devel` package is no longer available on Redhat 7 platform, and this causes the default recipe to break (does not converge).

Changes to the tests:
- Included `filesystem::default` recipe in the default testing recipe
- Added Redhat 7 vagrant box
- Added XFS filesystem test

Note: the xfsprogs package [is not available on Redhat 6](http://itnotesandscribblings.blogspot.ca/2014/09/xfs-on-red-hat-enterprise-linux-6.html), so I've opted to not include a Redhat 6 vagrant box in the tests. 

### Issues Resolved
#40 

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/filesystem/41)
<!-- Reviewable:end -->
