### PR TITLE
Reorganise code to only format disks once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 ### Changed
 
+## [0.13.0] - 2018-02-06
+
+- Remove possible double format of disks if force
+- Do not perform test mount if ignore\_existing and force
+- Use truthy value of ignore\_existing rather than nil?
+
 ## [0.12.1] - 2017-07-11
 - updated mount resource in providers/default.rb to notify directory resource immediately to fix mount permissions after mounting
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'help@sous-chefs.org'
 description      'Installs/Configures various filesystems'
 license          'Apache-2.0'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.12.1'
+version          '0.13.0'
 source_url       'https://github.com/sous-chefs/filesystem'
 issues_url       'https://github.com/sous-chefs/filesystem/issues'
 chef_version     '>= 12.0' if respond_to?(:chef_version)

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -148,18 +148,8 @@ action :create do
 
     if force
 
-      # We force create the filesystem and we ignore failures. This is sparta, etc.
       execute mkfs_cmd do
-        ignore_failure true
-        not_if generic_check_cmd
-      end
-
-      # We really will nuke existing filesystems with this one
-      execute mkfs_cmd do
-        ignore_failure true
-        not_if do
-          ignore_existing.nil?
-        end
+        not_if generic_check_cmd unless ignore_existing
       end
 
     else


### PR DESCRIPTION
Only format disks once and do not perform the test mount if ignoring
the existing content.

### Description

- the partition is only formatted once even if force and ignore_existing are true
- the ignore_existing is not longer tested to be nil and works as documented

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/filesystem/43)
<!-- Reviewable:end -->
