### PR TITLE
Fix idempotence for wait for device block

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -29,6 +29,7 @@ platforms:
     pid_one_command: /usr/lib/systemd/systemd
     intermediate_instructions:
       - RUN yum -y install lsof which systemd-sysv initscripts wget net-tools
+      - RUN cat /proc/mounts > /etc/fstab
 
 - name: debian-8
   driver:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,6 +4,10 @@ driver:
 provisioner:
   name: chef_zero
   deprecations_as_errors: true
+  enforce_idempotency: true
+  multiple_converge: 2
+  client_rb:
+    count_log_resource_updates: false
 
 verifier:
   name: inspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 ### Changed
+- Fix idempotence of 'wait for device' block
 
 ## [0.13.0] - 2018-02-06
 

--- a/libraries/fs.rb
+++ b/libraries/fs.rb
@@ -5,6 +5,7 @@ module FilesystemMod
   include Chef::Mixin::ShellOut
 
   MOUNT_EX_FAIL = 32 unless const_defined?(:MOUNT_EX_FAIL)
+  NET_FS_TYPES = %w(nfs cifs smp nbd).freeze unless const_defined?(:NET_FS_TYPES)
 
   # Check to determine if the device is mounted.
   def mounted?(device)
@@ -23,5 +24,10 @@ module FilesystemMod
       remount.error!
       false
     end
+  end
+
+  # Check if provided filesystem type is netfs
+  def netfs?(fstype)
+    NET_FS_TYPES.include? fstype
   end
 end

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -87,13 +87,6 @@ action :create do
 
   ruby_block 'wait for device' do
     block do
-      # TODO: does this effect bind mounts ?
-      net_fs_types = %w(nfs cifs smp nbd)
-      if net_fs_types.include? fstype
-        Chef::Log.info "#{fstype} is a netfs will not wait for block device"
-        return
-      end
-
       count = 0
       until ::File.exist?(device)
         count += 1
@@ -105,6 +98,7 @@ action :create do
         end
       end
     end
+    not_if { ::File.exist?(device) || netfs?(fstype) }
   end
 
   # We only try and create a filesystem if the device is existent and unmounted


### PR DESCRIPTION
### Description

Currently ruby block 'wait for device' will run every chef run and it will be reported as changed. This PR fixes such behaviour and adds idempotence check to test-kitchen. 

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/filesystem/44)
<!-- Reviewable:end -->
