### PR TITLE
Add the device_defer attribute to the filesystem resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unpublished
+
+- Add the device_defer attribute to the filesystem resource. If set to true and the backing device does not exist the resource returns without processing or error.
+
 ## 2.0.2 (2020-06-18)
 
 - Removed Dangerfile from rubocop.yml

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ Used to support the filesystem
 
 ## Atypical Behaviour Modifiers
 
+### `device_defer` Skip file system creation if the backing device does not exist. Defaults to false
+
 ### `force` Boolean (default: false)
 
 Set to true we unsafely create filesystems. If there is data it will be lost. Should not use this unless you are quite confident.

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -74,6 +74,8 @@ action :create do
         file.nil?
       end
     end
+  elsif new_resource.device_defer && !::File.exist?(device)
+    return
   end
 
   ruby_block 'wait for device' do

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -35,6 +35,7 @@ attribute :fstype, kind_of: String, default: 'ext3'
 attribute :mkfs_options, kind_of: String, default: ''
 attribute :package, kind_of: String
 attribute :recipe, kind_of: String
+attribute :device_defer, kind_of: [TrueClass, FalseClass], default: false
 
 # LVM and filebacked
 attribute :sparse, kind_of: [TrueClass, FalseClass], default: true

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -16,3 +16,30 @@ filesystem 'loop-1' do
   mount '/mnt/loop-1'
   action [:create, :enable, :mount]
 end
+
+filesystem 'dev1' do
+  device_defer true
+  fstype 'ext3'
+  size '10000'
+  device '/dev/dev1'
+  mount '/mnt/dev-1'
+  action [:create, :enable, :mount]
+end
+
+filesystem 'uuid1' do
+  device_defer true
+  fstype 'ext3'
+  size '10000'
+  uuid 'devuuid'
+  mount '/mnt/uuid-1'
+  action [:create, :enable, :mount]
+end
+
+filesystem 'label1' do
+  device_defer true
+  fstype 'ext3'
+  size '10000'
+  label 'label1'
+  mount '/mnt/label-1'
+  action [:create, :enable, :mount]
+end


### PR DESCRIPTION
### Description

Add an attribute to the filesystem resource to allow more sophisticated handling of errors when a backend device doesn't exist.

### Issues Resolved
#47

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable