### PR TITLE
Fix the check that prevents reinitialization of a file system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 - resolved cookstyle error: resources/default.rb:118:35 convention: `Style/RedundantCondition`
+- fix the check for an existing mountable filesystem before running mkfs again
 
 ## 3.0.2 (2020-09-16)
 

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -28,7 +28,7 @@ filesystem 'loop-2' do
   fstype 'ext3'
   file '/opt/loop.img'
   size '10000'
-  device '/dev/loop5'
+  device '/dev/loop6'
   mount '/mnt/loop-2'
   action [:create, :enable, :mount, :freeze]
 end
@@ -37,7 +37,7 @@ filesystem 'loop-3' do
   fstype 'ext3'
   file '/opt/loop.img'
   size '10000'
-  device '/dev/loop5'
+  device '/dev/loop7'
   mount '/mnt/loop-3'
   action [:create, :enable, :mount, :freeze, :unfreeze]
 end
@@ -66,5 +66,28 @@ filesystem 'label1' do
   size '10000'
   label 'label1'
   mount '/mnt/label-1'
+  action [:create, :enable, :mount]
+end
+
+# verify the idempotence of filesystem initialization
+# add a file
+# unmount it
+# create the file system again - should not run mkfs again which would wipe out the filet
+
+file '/mnt/loop-1/testfile'
+
+mount '/mnt/loop-1 unmount' do
+  action :unmount
+  device '/dev/loop5'
+  mount_point '/mnt/loop-1'
+end
+
+filesystem 'loop-1 remount' do
+  fstype 'ext3'
+  file '/opt/loop.img'
+  label 'loop-1'
+  size '10000'
+  device '/dev/loop5'
+  mount '/mnt/loop-1'
   action [:create, :enable, :mount]
 end

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -15,6 +15,11 @@ describe mount('/mnt/loop-1') do
   its('type') { should eq 'ext3' }
 end
 
+describe file('/mnt/loop-1/testfile') do
+  it { should exist }
+  it { should be_file }
+end
+
 if os.family == 'debian'
   describe etc_fstab.where { mount_point == '/mnt/nfs-1' } do
     its('file_system_type') { should cmp 'nfs' }


### PR DESCRIPTION
We need to check and see if a file system has been initialized
before running mkfs.  The check existed but was not being executed.

### Description

Do the check before running mkfs.  Add a test to verify the behavior.

### Issues Resolved

#99

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable