### PR TITLE
Remove nomkfs property from document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 - Remove delivery folder
+- Fix document: `nomkfs` option is not in `filesystem` resource
 
 ## 4.0.0 - *2021-10-14*
 

--- a/documentation/resources/filesystem.md
+++ b/documentation/resources/filesystem.md
@@ -120,10 +120,6 @@ Set to true we unsafely create filesystems. If there is data it will be lost. Sh
 
 Set to true we will ignore existing filesystems and recreate them. Double Dangerous and only for unsound behaviour. Use with 'force' true.
 
-### `nomkfs` Boolean (default: false)
-
-Set to true to disable creation of the filesystem.
-
 ### `nomount` Boolean (default: false)
 
 Set to true to disable mounting of the filesystem.


### PR DESCRIPTION
# Description

`nomkfs` property is not implemented in the `filesystem` resource.
To achieve the equivalent you can change

```ruby
actions %i[create enable mount]
```

to

```ruby
actions %i[enable mount]
```

## Issues Resolved

N/A

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
