### PR TITLE
Support use of symlinks for device paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Support use of symlinks for device paths
+
 ## 4.1.0 - *2024-12-09*
 
 - Add validation to the filesystem label property, limiting to a maximum length of 12 characters

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -153,7 +153,7 @@ action :create do
   wait_for_device unless ::File.exist?(device) || netfs?(fstype)
 
   # We only try and create a filesystem if the device exists and is unmounted
-  unless mounted?(device)
+  unless mounted?(device: device)
 
     # Install the filesystem's default package and recipes as configured in default attributes.
     fs_tools = node['filesystem_tools'].fetch(fstype, nil)
@@ -259,9 +259,7 @@ action :mount do
       fstype fstype
       options options
       action :mount
-      # Pathname.new(mount).mountpoint? would be a better check but might
-      # cause different behavior
-      not_if "mount | grep #{device}\" \" | grep #{mount}\" \""
+      not_if { mounted?(device: device, mountpoint: mount) }
     end
 
     # set directory attributes within the mounted file system


### PR DESCRIPTION
This change improves the mounted? check

1. Symlinks are now resolved to their canonical path
2. Checks if the device is mounted to a specific mount point

# Description

This pull request is similar to https://github.com/sous-chefs/filesystem/pull/130 by [jrmycanady](https://github.com/jrmycanady) but also canonicalizes device paths in /proc/mounts. This is necessary because device paths in /prod/mount can be symlinks as well. For example, /dev/mapper/system-root referes to /dev/dm-0.

## Issues Resolved

[129](https://github.com/sous-chefs/filesystem/issues/129) - filesystem tries to run mkfs every time when /dev/disk/by-id device path is used

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
