### PR TITLE
fix: resolve undefined local variable or method `label` error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Fix: initialise `label` local variable on creation of file system
+
 ## 4.2.0 - *2024-12-15*
 
 - Support use of symlinks for device paths

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,9 +150,6 @@ Standardise files with files in sous-chefs/repo-management
 
 ## Added
 
-[0.10.2]: https://github.com/sous-chefs/filesystem/compare/v0.8.2...v0.10.2
-[0.10.6]: https://github.com/sous-chefs/filesystem/compare/v0.10.2...v0.10.6
-[0.11.0]: https://github.com/sous-chefs/filesystem/compare/v0.10.6...v0.11.0
 [0.11.1]: https://github.com/sous-chefs/filesystem/compare/v0.11.0...v0.11.1
 [0.12.0]: https://github.com/sous-chefs/filesystem/compare/v0.11.1...v0.12.0
 [1.0.0]: https://github.com/sous-chefs/filesystem/compare/v0.12.0...v1.0.0

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -106,6 +106,7 @@ action_class do
 end
 
 action :create do
+  label = @new_resource.label
   fstype = @new_resource.fstype
   mkfs_options = @new_resource.mkfs_options
   ignore_existing = @new_resource.ignore_existing
@@ -123,7 +124,7 @@ action :create do
 
     # LVM
     # We use the lvm provider directly.
-    lvm_logical_volume new_resource.label do
+    lvm_logical_volume label do
       action :create
       group vg
       size size
@@ -167,7 +168,7 @@ action :create do
       packages.each { |keyed_package| package keyed_package.to_s }
     end
 
-    Chef::Log.info "filesystem #{new_resource.label} creating #{fstype} on #{device}"
+    Chef::Log.info "filesystem #{label} creating #{fstype} on #{device}"
 
     # Install the filesystem's default package and recipes as configured in default attributes.
     mkfs_force_options = node['filesystem_tools'].fetch(fstype, nil)


### PR DESCRIPTION
Obvious fix.

# Description

On Linux instances, after `filesystem` version `4.0.15` the Chef run fails as it tries to create a new filesystem. This is due to a local variable trying to be called, but not existing, as it's not set up in the default resource file.

## Issues Resolved

- https://github.com/sous-chefs/filesystem/issues/134

## Check List

- [ * ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ * ] New functionality includes testing - Fully tested across multiple OS's in Kitchen
- [ * ] New functionality has been documented in the README if applicable - Not applicable.
